### PR TITLE
feat(frontend): React Flow canvas with custom AWS nodes

### DIFF
--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,22 +1,88 @@
 'use client';
 
 import { useState } from 'react';
+import type { ParseResponse } from '@awsarchitect/shared';
 import { Upload } from '@/components/Upload';
+import { Canvas } from '@/components/Canvas';
+import { parseFile } from '@/lib/api';
+
+type AppState =
+  | { view: 'upload' }
+  | { view: 'loading' }
+  | { view: 'error'; message: string }
+  | { view: 'canvas'; data: ParseResponse; selectedNodeId: string | null };
 
 export default function Home() {
-  const [, setParsedFile] = useState<File | null>(null);
+  const [state, setState] = useState<AppState>({ view: 'upload' });
 
+  async function handleFileAccepted(file: File) {
+    setState({ view: 'loading' });
+    try {
+      const data = await parseFile(file);
+      setState({ view: 'canvas', data, selectedNodeId: null });
+    } catch (err) {
+      setState({ view: 'error', message: err instanceof Error ? err.message : 'Unknown error' });
+    }
+  }
+
+  if (state.view === 'loading') {
+    return (
+      <main className="flex min-h-screen items-center justify-center">
+        <p className="text-slate-400 animate-pulse">Parsing infrastructure...</p>
+      </main>
+    );
+  }
+
+  if (state.view === 'error') {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center gap-4">
+        <p className="text-red-400">{state.message}</p>
+        <button
+          onClick={() => setState({ view: 'upload' })}
+          className="px-4 py-2 text-sm rounded-md border border-slate-600 text-slate-300 hover:bg-navy-700 transition-colors"
+        >
+          Try again
+        </button>
+      </main>
+    );
+  }
+
+  if (state.view === 'canvas') {
+    return (
+      <div className="flex h-screen">
+        <div className="flex-1">
+          <Canvas
+            graphNodes={state.data.nodes}
+            graphEdges={state.data.edges}
+            onNodeSelect={(id) =>
+              setState((prev) =>
+                prev.view === 'canvas' ? { ...prev, selectedNodeId: id } : prev
+              )
+            }
+          />
+        </div>
+        {/* Sidebar placeholder — Step 6 */}
+        <div className="w-80 border-l border-slate-700 bg-navy-800 p-4 overflow-y-auto">
+          {state.selectedNodeId ? (
+            <div>
+              <p className="text-sm text-slate-400">Selected:</p>
+              <p className="text-slate-200 font-medium">{state.selectedNodeId}</p>
+            </div>
+          ) : (
+            <p className="text-sm text-slate-400">Click a node to inspect it</p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Default: upload view
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-8 p-8">
       <h1 className="text-4xl font-bold tracking-tight text-slate-100">AWSArchitect</h1>
       <p className="text-slate-400 text-sm">Upload a Terraform state file to visualize your infrastructure</p>
       <div className="w-full max-w-lg">
-        <Upload
-          onFileAccepted={(file) => {
-            setParsedFile(file);
-            console.log('File accepted:', file.name, file.size);
-          }}
-        />
+        <Upload onFileAccepted={handleFileAccepted} />
       </div>
     </main>
   );

--- a/apps/frontend/src/components/Canvas.tsx
+++ b/apps/frontend/src/components/Canvas.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import ReactFlow, {
+  Background,
+  Controls,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+  type Node,
+  type Edge,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import type { GraphNode, GraphEdge, GraphNodeData } from '@awsarchitect/shared';
+
+import { VpcNode } from './nodes/VpcNode';
+import { SubnetNode } from './nodes/SubnetNode';
+import { Ec2Node } from './nodes/Ec2Node';
+import { RdsNode } from './nodes/RdsNode';
+import { S3Node } from './nodes/S3Node';
+import { LambdaNode } from './nodes/LambdaNode';
+import { LbNode } from './nodes/LbNode';
+import { IgwNode } from './nodes/IgwNode';
+import { NatNode } from './nodes/NatNode';
+import { RouteTableNode } from './nodes/RouteTableNode';
+import { SecurityGroupNode } from './nodes/SecurityGroupNode';
+import { EipNode } from './nodes/EipNode';
+import { GenericNode } from './nodes/GenericNode';
+
+// MUST be defined at module scope — inside component causes infinite re-renders
+const nodeTypes = {
+  vpcNode: VpcNode,
+  subnetNode: SubnetNode,
+  ec2Node: Ec2Node,
+  rdsNode: RdsNode,
+  s3Node: S3Node,
+  lambdaNode: LambdaNode,
+  lbNode: LbNode,
+  igwNode: IgwNode,
+  natNode: NatNode,
+  routeTableNode: RouteTableNode,
+  securityGroupNode: SecurityGroupNode,
+  eipNode: EipNode,
+  genericNode: GenericNode,
+};
+
+interface CanvasProps {
+  graphNodes: GraphNode[];
+  graphEdges: GraphEdge[];
+  onNodeSelect: (nodeId: string | null) => void;
+}
+
+export function Canvas({ graphNodes, graphEdges, onNodeSelect }: CanvasProps) {
+  const [nodes, , onNodesChange] = useNodesState(graphNodes as Node<GraphNodeData>[]);
+  const [edges, , onEdgesChange] = useEdgesState(graphEdges as Edge[]);
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      nodeTypes={nodeTypes}
+      onNodeClick={(_, node) => onNodeSelect(node.id)}
+      onPaneClick={() => onNodeSelect(null)}
+      fitView
+      minZoom={0.1}
+      maxZoom={2}
+      defaultEdgeOptions={{ animated: false, style: { stroke: '#475569' } }}
+    >
+      <Background color="#1e293b" gap={20} size={1} />
+      <Controls className="!bg-navy-800 !border-navy-600" />
+      <MiniMap
+        nodeColor={(node) => {
+          switch (node.type) {
+            case 'vpcNode':            return '#3b82f6';
+            case 'subnetNode':         return '#10b981';
+            case 'ec2Node':            return '#f59e0b';
+            case 'rdsNode':            return '#a855f7';
+            case 's3Node':             return '#ec4899';
+            case 'lambdaNode':         return '#f97316';
+            case 'lbNode':             return '#06b6d4';
+            case 'securityGroupNode':  return '#eab308';
+            case 'igwNode':            return '#0ea5e9';
+            case 'natNode':            return '#14b8a6';
+            case 'eipNode':            return '#f43f5e';
+            default:                   return '#64748b';
+          }
+        }}
+        maskColor="rgba(10, 15, 30, 0.7)"
+      />
+    </ReactFlow>
+  );
+}

--- a/apps/frontend/src/components/nodes/Ec2Node.tsx
+++ b/apps/frontend/src/components/nodes/Ec2Node.tsx
@@ -1,0 +1,18 @@
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { GraphNodeData } from '@awsarchitect/shared';
+
+export function Ec2Node({ data, selected }: NodeProps<GraphNodeData>) {
+  const instanceType = data.resource.attributes['instance_type'] as string | undefined;
+
+  return (
+    <div className={`node-card border-amber-500 ${selected ? 'ring-2 ring-white' : ''}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-base">🖥️</span>
+        <span className="truncate">{data.label}</span>
+      </div>
+      {instanceType && <span className="text-xs text-slate-400">{instanceType}</span>}
+      <Handle type="target" position={Position.Left} className="!bg-amber-400" />
+      <Handle type="source" position={Position.Right} className="!bg-amber-400" />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/nodes/EipNode.tsx
+++ b/apps/frontend/src/components/nodes/EipNode.tsx
@@ -1,0 +1,18 @@
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { GraphNodeData } from '@awsarchitect/shared';
+
+export function EipNode({ data, selected }: NodeProps<GraphNodeData>) {
+  const publicIp = data.resource.attributes['public_ip'] as string | undefined;
+
+  return (
+    <div className={`node-card border-rose-500 ${selected ? 'ring-2 ring-white' : ''}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-base">📍</span>
+        <span className="truncate">{data.label}</span>
+      </div>
+      {publicIp && <span className="text-xs text-slate-400">{publicIp}</span>}
+      <Handle type="target" position={Position.Left} className="!bg-rose-400" />
+      <Handle type="source" position={Position.Right} className="!bg-rose-400" />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/nodes/GenericNode.tsx
+++ b/apps/frontend/src/components/nodes/GenericNode.tsx
@@ -1,0 +1,16 @@
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { GraphNodeData } from '@awsarchitect/shared';
+
+export function GenericNode({ data, selected }: NodeProps<GraphNodeData>) {
+  return (
+    <div className={`node-card border-slate-500 ${selected ? 'ring-2 ring-white' : ''}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-base">📦</span>
+        <span className="truncate">{data.label}</span>
+      </div>
+      <span className="text-xs text-slate-400">{data.resource.type}</span>
+      <Handle type="target" position={Position.Left} className="!bg-slate-400" />
+      <Handle type="source" position={Position.Right} className="!bg-slate-400" />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/nodes/IgwNode.tsx
+++ b/apps/frontend/src/components/nodes/IgwNode.tsx
@@ -1,0 +1,16 @@
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { GraphNodeData } from '@awsarchitect/shared';
+
+export function IgwNode({ data, selected }: NodeProps<GraphNodeData>) {
+  return (
+    <div className={`node-card border-sky-500 ${selected ? 'ring-2 ring-white' : ''}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-base">🌍</span>
+        <span className="truncate">{data.label}</span>
+      </div>
+      <span className="text-xs text-slate-400">Internet Gateway</span>
+      <Handle type="target" position={Position.Left} className="!bg-sky-400" />
+      <Handle type="source" position={Position.Right} className="!bg-sky-400" />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/nodes/LambdaNode.tsx
+++ b/apps/frontend/src/components/nodes/LambdaNode.tsx
@@ -1,0 +1,18 @@
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { GraphNodeData } from '@awsarchitect/shared';
+
+export function LambdaNode({ data, selected }: NodeProps<GraphNodeData>) {
+  const runtime = data.resource.attributes['runtime'] as string | undefined;
+
+  return (
+    <div className={`node-card border-orange-500 ${selected ? 'ring-2 ring-white' : ''}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-base">⚡</span>
+        <span className="truncate">{data.label}</span>
+      </div>
+      {runtime && <span className="text-xs text-slate-400">{runtime}</span>}
+      <Handle type="target" position={Position.Left} className="!bg-orange-400" />
+      <Handle type="source" position={Position.Right} className="!bg-orange-400" />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/nodes/LbNode.tsx
+++ b/apps/frontend/src/components/nodes/LbNode.tsx
@@ -1,0 +1,18 @@
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { GraphNodeData } from '@awsarchitect/shared';
+
+export function LbNode({ data, selected }: NodeProps<GraphNodeData>) {
+  const lbType = data.resource.attributes['load_balancer_type'] as string | undefined;
+
+  return (
+    <div className={`node-card border-cyan-500 ${selected ? 'ring-2 ring-white' : ''}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-base">⚖️</span>
+        <span className="truncate">{data.label}</span>
+      </div>
+      {lbType && <span className="text-xs text-slate-400">{lbType}</span>}
+      <Handle type="target" position={Position.Left} className="!bg-cyan-400" />
+      <Handle type="source" position={Position.Right} className="!bg-cyan-400" />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/nodes/NatNode.tsx
+++ b/apps/frontend/src/components/nodes/NatNode.tsx
@@ -1,0 +1,16 @@
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { GraphNodeData } from '@awsarchitect/shared';
+
+export function NatNode({ data, selected }: NodeProps<GraphNodeData>) {
+  return (
+    <div className={`node-card border-teal-500 ${selected ? 'ring-2 ring-white' : ''}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-base">🔀</span>
+        <span className="truncate">{data.label}</span>
+      </div>
+      <span className="text-xs text-slate-400">NAT Gateway</span>
+      <Handle type="target" position={Position.Left} className="!bg-teal-400" />
+      <Handle type="source" position={Position.Right} className="!bg-teal-400" />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/nodes/RdsNode.tsx
+++ b/apps/frontend/src/components/nodes/RdsNode.tsx
@@ -1,0 +1,18 @@
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { GraphNodeData } from '@awsarchitect/shared';
+
+export function RdsNode({ data, selected }: NodeProps<GraphNodeData>) {
+  const engine = data.resource.attributes['engine'] as string | undefined;
+
+  return (
+    <div className={`node-card border-purple-500 ${selected ? 'ring-2 ring-white' : ''}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-base">🗄️</span>
+        <span className="truncate">{data.label}</span>
+      </div>
+      {engine && <span className="text-xs text-slate-400">{engine}</span>}
+      <Handle type="target" position={Position.Left} className="!bg-purple-400" />
+      <Handle type="source" position={Position.Right} className="!bg-purple-400" />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/nodes/RouteTableNode.tsx
+++ b/apps/frontend/src/components/nodes/RouteTableNode.tsx
@@ -1,0 +1,16 @@
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { GraphNodeData } from '@awsarchitect/shared';
+
+export function RouteTableNode({ data, selected }: NodeProps<GraphNodeData>) {
+  return (
+    <div className={`node-card border-indigo-500 ${selected ? 'ring-2 ring-white' : ''}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-base">🗺️</span>
+        <span className="truncate">{data.label}</span>
+      </div>
+      <span className="text-xs text-slate-400">Route Table</span>
+      <Handle type="target" position={Position.Left} className="!bg-indigo-400" />
+      <Handle type="source" position={Position.Right} className="!bg-indigo-400" />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/nodes/S3Node.tsx
+++ b/apps/frontend/src/components/nodes/S3Node.tsx
@@ -1,0 +1,18 @@
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { GraphNodeData } from '@awsarchitect/shared';
+
+export function S3Node({ data, selected }: NodeProps<GraphNodeData>) {
+  const bucket = data.resource.attributes['bucket'] as string | undefined;
+
+  return (
+    <div className={`node-card border-pink-500 ${selected ? 'ring-2 ring-white' : ''}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-base">🪣</span>
+        <span className="truncate">{data.label}</span>
+      </div>
+      {bucket && <span className="text-xs text-slate-400">{bucket}</span>}
+      <Handle type="target" position={Position.Left} className="!bg-pink-400" />
+      <Handle type="source" position={Position.Right} className="!bg-pink-400" />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/nodes/SecurityGroupNode.tsx
+++ b/apps/frontend/src/components/nodes/SecurityGroupNode.tsx
@@ -1,0 +1,18 @@
+import { Handle, Position, type NodeProps } from 'reactflow';
+import type { GraphNodeData } from '@awsarchitect/shared';
+
+export function SecurityGroupNode({ data, selected }: NodeProps<GraphNodeData>) {
+  const name = data.resource.attributes['name'] as string | undefined;
+
+  return (
+    <div className={`node-card border-yellow-500 ${selected ? 'ring-2 ring-white' : ''}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-base">🛡️</span>
+        <span className="truncate">{data.label}</span>
+      </div>
+      {name && <span className="text-xs text-slate-400">{name}</span>}
+      <Handle type="target" position={Position.Left} className="!bg-yellow-400" />
+      <Handle type="source" position={Position.Right} className="!bg-yellow-400" />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/nodes/SubnetNode.tsx
+++ b/apps/frontend/src/components/nodes/SubnetNode.tsx
@@ -1,0 +1,27 @@
+import type { NodeProps } from 'reactflow';
+import type { GraphNodeData } from '@awsarchitect/shared';
+
+export function SubnetNode({ data, selected }: NodeProps<GraphNodeData>) {
+  const cidr = data.resource.attributes['cidr_block'] as string | undefined;
+  const isPublic = data.resource.attributes['map_public_ip_on_launch'] === true;
+
+  return (
+    <div
+      className={`
+        h-full w-full rounded-md border-2 border-emerald-500/50 bg-emerald-950/15 p-3
+        ${selected ? 'ring-2 ring-white' : ''}
+      `}
+    >
+      <div className="flex items-center gap-2 text-sm font-medium text-emerald-300">
+        <span>🔲</span>
+        <span>{data.label}</span>
+        {cidr && <span className="text-xs text-emerald-400/60">{cidr}</span>}
+        {isPublic && (
+          <span className="text-[10px] uppercase tracking-wider text-emerald-500 bg-emerald-500/10 px-1.5 py-0.5 rounded">
+            public
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/nodes/VpcNode.tsx
+++ b/apps/frontend/src/components/nodes/VpcNode.tsx
@@ -1,0 +1,21 @@
+import type { NodeProps } from 'reactflow';
+import type { GraphNodeData } from '@awsarchitect/shared';
+
+export function VpcNode({ data, selected }: NodeProps<GraphNodeData>) {
+  const cidr = data.resource.attributes['cidr_block'] as string | undefined;
+
+  return (
+    <div
+      className={`
+        h-full w-full rounded-lg border-2 border-blue-500/60 bg-blue-950/20 p-3
+        ${selected ? 'ring-2 ring-white' : ''}
+      `}
+    >
+      <div className="flex items-center gap-2 text-sm font-medium text-blue-300">
+        <span>🌐</span>
+        <span>{data.label}</span>
+        {cidr && <span className="text-xs text-blue-400/70">{cidr}</span>}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -1,0 +1,32 @@
+import type { ParseResponse, ApiError } from '@awsarchitect/shared';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+
+export async function parseFile(file: File): Promise<ParseResponse> {
+  const form = new FormData();
+  form.append('tfstate', file);
+
+  const res = await fetch(`${API_BASE}/api/parse`, { method: 'POST', body: form });
+
+  if (!res.ok) {
+    const err: ApiError = await res.json();
+    throw new Error(err.details ?? err.error);
+  }
+
+  return res.json();
+}
+
+export async function parseRaw(tfstate: string): Promise<ParseResponse> {
+  const res = await fetch(`${API_BASE}/api/parse/raw`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tfstate }),
+  });
+
+  if (!res.ok) {
+    const err: ApiError = await res.json();
+    throw new Error(err.details ?? err.error);
+  }
+
+  return res.json();
+}

--- a/test/sample.tfstate
+++ b/test/sample.tfstate
@@ -1,0 +1,217 @@
+{
+  "version": 4,
+  "terraform_version": "1.6.0",
+  "serial": 42,
+  "lineage": "abc123",
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "main",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "vpc-0main001",
+            "cidr_block": "10.0.0.0/16",
+            "enable_dns_hostnames": true,
+            "tags": { "Name": "main-vpc", "Environment": "dev" }
+          },
+          "dependencies": []
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "public_1",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "subnet-pub001",
+            "vpc_id": "vpc-0main001",
+            "cidr_block": "10.0.1.0/24",
+            "availability_zone": "us-east-1a",
+            "map_public_ip_on_launch": true,
+            "tags": { "Name": "public-subnet-1" }
+          },
+          "dependencies": ["aws_vpc.main"]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_subnet",
+      "name": "private_1",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "subnet-priv001",
+            "vpc_id": "vpc-0main001",
+            "cidr_block": "10.0.2.0/24",
+            "availability_zone": "us-east-1b",
+            "map_public_ip_on_launch": false,
+            "tags": { "Name": "private-subnet-1" }
+          },
+          "dependencies": ["aws_vpc.main"]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_internet_gateway",
+      "name": "igw",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "igw-0001",
+            "vpc_id": "vpc-0main001",
+            "tags": { "Name": "main-igw" }
+          },
+          "dependencies": ["aws_vpc.main"]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_eip",
+      "name": "nat_eip",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "eip-0001",
+            "allocation_id": "eipalloc-0001",
+            "public_ip": "54.10.20.30",
+            "tags": { "Name": "nat-eip" }
+          },
+          "dependencies": []
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_nat_gateway",
+      "name": "nat",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "nat-0001",
+            "subnet_id": "subnet-pub001",
+            "allocation_id": "eipalloc-0001",
+            "tags": { "Name": "main-nat" }
+          },
+          "dependencies": ["aws_eip.nat_eip", "aws_subnet.public_1"]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "app_sg",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "sg-0app001",
+            "vpc_id": "vpc-0main001",
+            "name": "app-sg",
+            "description": "Allow HTTP and HTTPS",
+            "tags": { "Name": "app-sg" }
+          },
+          "dependencies": ["aws_vpc.main"]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "web",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "i-0ec2web001",
+            "ami": "ami-0abcdef1234567890",
+            "instance_type": "t3.micro",
+            "subnet_id": "subnet-pub001",
+            "vpc_security_group_ids": ["sg-0app001"],
+            "tags": { "Name": "web-server" }
+          },
+          "dependencies": ["aws_subnet.public_1", "aws_security_group.app_sg"]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_db_instance",
+      "name": "postgres",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "id": "db-postgres001",
+            "identifier": "mydb",
+            "engine": "postgres",
+            "engine_version": "14.7",
+            "instance_class": "db.t3.micro",
+            "subnet_id": "subnet-priv001",
+            "vpc_security_group_ids": ["sg-0app001"],
+            "tags": { "Name": "postgres-db" }
+          },
+          "dependencies": ["aws_subnet.private_1", "aws_security_group.app_sg"]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_lb",
+      "name": "app_alb",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/app-alb/abcdef",
+            "name": "app-alb",
+            "load_balancer_type": "application",
+            "subnet_ids": ["subnet-pub001"],
+            "security_groups": ["sg-0app001"],
+            "tags": { "Name": "app-alb" }
+          },
+          "dependencies": ["aws_subnet.public_1", "aws_security_group.app_sg"]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "assets",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "my-assets-bucket-20240101",
+            "bucket": "my-assets-bucket-20240101",
+            "tags": { "Name": "assets-bucket" }
+          },
+          "dependencies": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add API client (`lib/api.ts`) with `parseFile()` and `parseRaw()` functions
- Build 13 custom node components: VPC, Subnet (containers), EC2, RDS, S3, Lambda, LB, IGW, NAT, Route Table, Security Group, EIP, Generic
- Add Canvas component with React Flow, MiniMap, Controls, and Background
- Wire page.tsx with state machine: upload → loading → canvas (or error)
- Add `test/sample.tfstate` for manual testing

## Verified with Playwright
- Upload zone accepts `.tfstate` file
- Canvas renders VPC → Subnet → Resource hierarchy correctly
- Node click highlights and updates sidebar
- MiniMap shows color-coded nodes
- Zoom/pan controls work

Closes #5