### PR TITLE
feat: cost estimation overlay with per-node badges (#85)

### DIFF
--- a/apps/frontend/src/components/CostPanel.tsx
+++ b/apps/frontend/src/components/CostPanel.tsx
@@ -1,0 +1,74 @@
+import type { CostEstimate } from '@/lib/costEstimator';
+import { formatCost, totalMonthlyCost } from '@/lib/costEstimator';
+import type { ProviderFrontendConfig } from '@/providers/types';
+import { GenericIcon } from './nodes/icons/AwsIcons';
+
+interface CostPanelProps {
+  estimates: CostEstimate[];
+  providerConfig: ProviderFrontendConfig;
+  onSelectResource?: (id: string) => void;
+  onClose: () => void;
+}
+
+export function CostPanel({ estimates, providerConfig, onSelectResource, onClose }: CostPanelProps) {
+  const total = totalMonthlyCost(estimates);
+  const sorted = [...estimates].sort((a, b) => b.monthlyCost - a.monthlyCost);
+
+  return (
+    <div className="absolute bottom-4 right-4 z-20 w-72 rounded-xl bg-white/95 dark:bg-slate-800/95 backdrop-blur-sm border border-slate-200 dark:border-slate-700 shadow-xl overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-slate-100 dark:border-slate-700 bg-emerald-50/50 dark:bg-emerald-950/20">
+        <div className="flex items-center gap-2">
+          <svg className="h-4 w-4 text-emerald-600 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span className="text-xs font-semibold text-emerald-700 dark:text-emerald-300">
+            Est. {formatCost(total)}/mo
+          </span>
+        </div>
+        <button
+          onClick={onClose}
+          className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+        >
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+      {/* List */}
+      <div className="max-h-64 overflow-y-auto py-1">
+        {sorted.map((est) => {
+          const config = providerConfig.typeConfig[est.resourceType] ?? {
+            label: est.resourceType.replace(/^(aws_|azurerm_|google_)/, ''),
+            Icon: GenericIcon,
+          };
+          const { Icon } = config;
+          return (
+            <button
+              key={est.resourceId}
+              onClick={() => onSelectResource?.(est.resourceId)}
+              className="flex items-center gap-2 w-full px-4 py-1.5 text-xs hover:bg-slate-50 dark:hover:bg-slate-700/50 transition-colors"
+            >
+              <Icon className="h-4 w-4 shrink-0 text-slate-500" />
+              <span className="text-slate-700 dark:text-slate-300 flex-1 text-left truncate">{est.label}</span>
+              <span className="font-semibold text-emerald-600 dark:text-emerald-400 tabular-nums whitespace-nowrap">
+                {formatCost(est.monthlyCost)}
+              </span>
+            </button>
+          );
+        })}
+        {sorted.length === 0 && (
+          <p className="px-4 py-3 text-xs text-slate-400 text-center">No estimable resources</p>
+        )}
+      </div>
+      {/* Footer */}
+      <div className="px-4 py-2.5 border-t border-slate-100 dark:border-slate-700 bg-amber-50/50 dark:bg-amber-950/10">
+        <p className="text-[10px] text-amber-700/70 dark:text-amber-400/60 leading-relaxed">
+          Estimates only. Based on approximate on-demand list prices (us-east-1).
+          Not a substitute for official cloud pricing calculators.
+          No guarantee of accuracy — do not use for budgeting or financial decisions.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/lib/costEstimator.ts
+++ b/apps/frontend/src/lib/costEstimator.ts
@@ -1,0 +1,174 @@
+import type { CloudResource } from '@infragraph/shared';
+
+export interface CostEstimate {
+  resourceId: string;
+  resourceType: string;
+  monthlyCost: number;
+  label: string; // e.g. "t3.micro" or "db.t3.medium"
+}
+
+// ─── AWS Pricing (us-east-1 on-demand, approximate USD/month) ────────────────
+
+const AWS_EC2_PRICING: Record<string, number> = {
+  't2.nano': 4.18, 't2.micro': 8.35, 't2.small': 16.71, 't2.medium': 33.41,
+  't2.large': 66.82, 't2.xlarge': 133.63, 't2.2xlarge': 267.26,
+  't3.nano': 3.80, 't3.micro': 7.59, 't3.small': 15.18, 't3.medium': 30.37,
+  't3.large': 60.74, 't3.xlarge': 121.47, 't3.2xlarge': 242.94,
+  'm5.large': 69.12, 'm5.xlarge': 138.24, 'm5.2xlarge': 276.48, 'm5.4xlarge': 552.96,
+  'm6i.large': 69.12, 'm6i.xlarge': 138.24, 'm6i.2xlarge': 276.48,
+  'c5.large': 61.20, 'c5.xlarge': 122.40, 'c5.2xlarge': 244.80,
+  'r5.large': 90.72, 'r5.xlarge': 181.44, 'r5.2xlarge': 362.88,
+};
+
+const AWS_RDS_PRICING: Record<string, number> = {
+  'db.t3.micro': 12.41, 'db.t3.small': 24.82, 'db.t3.medium': 49.64,
+  'db.t3.large': 99.28, 'db.t3.xlarge': 198.56, 'db.t3.2xlarge': 397.12,
+  'db.m5.large': 124.10, 'db.m5.xlarge': 248.20, 'db.m5.2xlarge': 496.40,
+  'db.r5.large': 175.20, 'db.r5.xlarge': 350.40, 'db.r5.2xlarge': 700.80,
+};
+
+const AWS_FIXED_COSTS: Record<string, number> = {
+  aws_nat_gateway: 32.40,        // ~$0.045/hr
+  aws_lb: 16.20,                 // ~$0.0225/hr (ALB)
+  aws_alb: 16.20,
+  aws_eip: 3.60,                 // ~$0.005/hr when unattached
+  aws_internet_gateway: 0,       // Free
+  aws_vpc: 0,                    // Free
+  aws_subnet: 0,                 // Free
+  aws_security_group: 0,         // Free
+  aws_route_table: 0,            // Free
+  aws_s3_bucket: 2.30,           // ~$0.023/GB, assume 100GB baseline
+  aws_lambda_function: 0,        // Pay-per-invocation, can't estimate statically
+};
+
+// ─── Azure Pricing (approximate USD/month) ───────────────────────────────────
+
+const AZURE_VM_PRICING: Record<string, number> = {
+  'Standard_B1s': 7.59, 'Standard_B1ms': 15.18, 'Standard_B2s': 30.37,
+  'Standard_B2ms': 60.74, 'Standard_D2s_v3': 70.08, 'Standard_D4s_v3': 140.16,
+  'Standard_D2s_v5': 69.35, 'Standard_D4s_v5': 138.70,
+};
+
+const AZURE_FIXED_COSTS: Record<string, number> = {
+  azurerm_virtual_network: 0,
+  azurerm_subnet: 0,
+  azurerm_network_security_group: 0,
+  azurerm_public_ip: 3.60,
+  azurerm_lb: 18.00,
+  azurerm_storage_account: 5.00,  // Approximate baseline
+  azurerm_sql_server: 0,          // Server itself is free, databases cost
+  azurerm_sql_database: 15.00,    // Basic tier
+  azurerm_mssql_server: 0,
+  azurerm_mssql_database: 15.00,
+};
+
+// ─── GCP Pricing (approximate USD/month) ─────────────────────────────────────
+
+const GCP_VM_PRICING: Record<string, number> = {
+  'e2-micro': 6.11, 'e2-small': 12.23, 'e2-medium': 24.46,
+  'n1-standard-1': 24.27, 'n1-standard-2': 48.55, 'n1-standard-4': 97.09,
+  'n2-standard-2': 48.92, 'n2-standard-4': 97.83,
+};
+
+const GCP_FIXED_COSTS: Record<string, number> = {
+  google_compute_network: 0,
+  google_compute_subnetwork: 0,
+  google_compute_firewall: 0,
+  google_compute_address: 7.20,
+  google_compute_router: 0,
+  google_compute_router_nat: 32.40,
+  google_storage_bucket: 2.30,
+  google_sql_database_instance: 25.00, // Small instance baseline
+};
+
+// ─── Estimator ───────────────────────────────────────────────────────────────
+
+function estimateAws(r: CloudResource): number | null {
+  // EC2
+  if (r.type === 'aws_instance') {
+    const instanceType = r.attributes['instance_type'] as string | undefined;
+    if (instanceType && AWS_EC2_PRICING[instanceType]) return AWS_EC2_PRICING[instanceType];
+    if (instanceType) return 30; // Unknown instance type fallback
+    return null;
+  }
+  // RDS
+  if (r.type === 'aws_db_instance') {
+    const instanceClass = r.attributes['instance_class'] as string | undefined;
+    if (instanceClass && AWS_RDS_PRICING[instanceClass]) return AWS_RDS_PRICING[instanceClass];
+    if (instanceClass) return 50; // Unknown class fallback
+    return null;
+  }
+  // Fixed-cost resources
+  if (r.type in AWS_FIXED_COSTS) return AWS_FIXED_COSTS[r.type];
+  return null;
+}
+
+function estimateAzure(r: CloudResource): number | null {
+  // VMs
+  if (r.type.includes('virtual_machine')) {
+    const size = r.attributes['size'] as string | undefined
+      ?? r.attributes['vm_size'] as string | undefined;
+    if (size && AZURE_VM_PRICING[size]) return AZURE_VM_PRICING[size];
+    if (size) return 50;
+    return null;
+  }
+  if (r.type in AZURE_FIXED_COSTS) return AZURE_FIXED_COSTS[r.type];
+  return null;
+}
+
+function estimateGcp(r: CloudResource): number | null {
+  // Compute instances
+  if (r.type === 'google_compute_instance') {
+    const machineType = r.attributes['machine_type'] as string | undefined;
+    if (machineType) {
+      // machine_type can be a full path like "zones/us-central1-a/machineTypes/e2-micro"
+      const shortType = machineType.split('/').pop() ?? machineType;
+      if (GCP_VM_PRICING[shortType]) return GCP_VM_PRICING[shortType];
+      return 30;
+    }
+    return null;
+  }
+  if (r.type in GCP_FIXED_COSTS) return GCP_FIXED_COSTS[r.type];
+  return null;
+}
+
+export function estimateCosts(resources: CloudResource[]): CostEstimate[] {
+  const estimates: CostEstimate[] = [];
+
+  for (const r of resources) {
+    let cost: number | null = null;
+
+    if (r.provider === 'aws') cost = estimateAws(r);
+    else if (r.provider === 'azure') cost = estimateAzure(r);
+    else if (r.provider === 'gcp') cost = estimateGcp(r);
+
+    if (cost !== null && cost > 0) {
+      const label =
+        (r.attributes['instance_type'] as string) ??
+        (r.attributes['instance_class'] as string) ??
+        (r.attributes['size'] as string) ??
+        (r.attributes['machine_type'] as string)?.split('/').pop() ??
+        r.type.replace(/^(aws_|azurerm_|google_)/, '');
+
+      estimates.push({
+        resourceId: r.id,
+        resourceType: r.type,
+        monthlyCost: cost,
+        label,
+      });
+    }
+  }
+
+  return estimates;
+}
+
+export function formatCost(cost: number): string {
+  if (cost >= 1000) return `$${(cost / 1000).toFixed(1)}k`;
+  if (cost >= 100) return `$${Math.round(cost)}`;
+  if (cost >= 10) return `$${cost.toFixed(1)}`;
+  return `$${cost.toFixed(2)}`;
+}
+
+export function totalMonthlyCost(estimates: CostEstimate[]): number {
+  return estimates.reduce((sum, e) => sum + e.monthlyCost, 0);
+}


### PR DESCRIPTION
## Summary
- Adds a **cost estimation overlay** that displays approximate monthly costs on each resource node in the graph view
- Cost badges use CSS `::after` pseudo-elements (zero changes to 30+ node components)
- **CostPanel** component shows a sorted cost breakdown with per-resource icons
- **Table view** gains a sortable "Est. Cost" column when costs are toggled on
- Legal disclaimer included: "Estimates only — not for budgeting or financial decisions"
- Supports AWS, Azure, and GCP with static on-demand pricing tables

## Changes
- `apps/frontend/src/lib/costEstimator.ts` — Pricing tables + estimation engine
- `apps/frontend/src/components/CostPanel.tsx` — Floating cost breakdown panel
- `apps/frontend/src/components/Canvas.tsx` — CSS cost badge injection
- `apps/frontend/src/components/HomePage.tsx` — Cost toggle button + wiring
- `apps/frontend/src/components/InventoryTable.tsx` — Cost column in table view

## Test plan
- [x] Visual smoke test: cost badges appear on billable nodes (NAT, EC2, RDS, ALB, EIP, S3)
- [x] Free resources (VPC, Subnet, IGW, SG) show no badge
- [x] CostPanel shows sorted breakdown with correct totals
- [x] Table view shows Est. Cost column with sortable header
- [x] Legal disclaimer visible in panel footer and table footer
- [x] Toggle off hides badges and panel
- [x] Lint, typecheck, build all pass
- [x] All 90 unit tests pass

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)