### PR TITLE
feat: enhanced minimap with resource colors (#82)

### DIFF
--- a/apps/frontend/src/components/Canvas.tsx
+++ b/apps/frontend/src/components/Canvas.tsx
@@ -421,7 +421,15 @@ export const Canvas = forwardRef<CanvasHandle, CanvasProps>(function Canvas(
         <Controls />
         <MiniMap
           nodeColor={providerConfig.minimapNodeColor}
-          maskColor="rgba(248, 250, 252, 0.7)"
+          nodeStrokeColor={providerConfig.minimapNodeColor}
+          nodeStrokeWidth={2}
+          nodeBorderRadius={3}
+          maskColor={document.documentElement.classList.contains('dark')
+            ? 'rgba(15, 23, 42, 0.75)'
+            : 'rgba(248, 250, 252, 0.7)'}
+          pannable
+          zoomable
+          className="!bg-white/80 dark:!bg-slate-900/80 !border !border-slate-200 dark:!border-slate-700 !rounded-lg !shadow-lg"
         />
       </ReactFlow>
       {showPlanLegend && (


### PR DESCRIPTION
## Summary
- Enhanced minimap with **resource type colors** and strokes for better node visibility
- **Dark mode aware** mask color — properly dark in dark mode, light in light mode
- Minimap is now **pannable and zoomable** for easier navigation
- Styled container with border, rounded corners, and shadow

## Changes
- `apps/frontend/src/components/Canvas.tsx` — Enhanced MiniMap props

## Test plan
- [x] Minimap nodes colored by resource type (VPC green, EC2 orange, RDS blue, SG red, etc.)
- [x] Node strokes match fill colors for visibility
- [x] Dark mode: slate mask background
- [x] Light mode: white mask background
- [x] Minimap is pannable (drag to pan viewport)
- [x] Minimap is zoomable (scroll to zoom)
- [x] Lint, typecheck, build all pass

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)