### PR TITLE
ui: simplify view toggle, add number badge, minimap toggle

### DIFF
--- a/apps/frontend/src/components/HomePage.tsx
+++ b/apps/frontend/src/components/HomePage.tsx
@@ -52,12 +52,12 @@ export function HomePage() {
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [blastRadiusMode, setBlastRadiusMode] = useState(false);
   const [blastRadiusCount, setBlastRadiusCount] = useState(0);
-  const [viewMode, setViewMode] = useState<'graph' | 'table' | 'map'>('graph');
+  const [viewMode, setViewMode] = useState<'graph' | 'table'>('graph');
   const [showSecurity, setShowSecurity] = useState(false);
   const [layoutMode, setLayoutMode] = useState<LayoutMode>('hierarchical');
   const [showLayoutMenu, setShowLayoutMenu] = useState(false);
   const [showCosts, setShowCosts] = useState(false);
-  const [showViewMenu, setShowViewMenu] = useState(false);
+  const [showMinimap, setShowMinimap] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const searchBarRef = useRef<SearchBarHandle>(null);
   const canvasRef = useRef<CanvasHandle>(null);
@@ -540,52 +540,41 @@ export function HomePage() {
                   </span>
                 )}
               </button>
-              {/* View mode dropdown */}
-              <div className="relative">
+              {/* View toggle: shows "Table" in graph mode, "Graph" in table mode */}
+              <button
+                onClick={() => setViewMode((v) => v === 'graph' ? 'table' : 'graph')}
+                className="flex items-center gap-1.5 rounded-lg bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm border border-slate-200 dark:border-slate-700 px-3 py-1.5 shadow-sm text-xs text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:border-slate-300 transition-colors"
+                title={viewMode === 'graph' ? 'Switch to table view' : 'Switch to graph view'}
+              >
+                {viewMode === 'graph' ? (
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 01-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0112 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M12 10.875v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125M13.125 12h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125M20.625 12c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5M12 14.625v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 14.625c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m0 0v.75" />
+                  </svg>
+                ) : (
+                  <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 14.25v2.25m3-4.5v4.5m3-6.75v6.75m3-9v9M6 20.25h12A2.25 2.25 0 0020.25 18V6A2.25 2.25 0 0018 3.75H6A2.25 2.25 0 003.75 6v12A2.25 2.25 0 006 20.25z" />
+                  </svg>
+                )}
+                <span className="hidden xl:inline">{viewMode === 'graph' ? 'Table' : 'Graph'}</span>
+              </button>
+              {/* Minimap toggle (graph mode only) */}
+              {viewMode === 'graph' && (
                 <button
-                  onClick={() => setShowViewMenu((v) => !v)}
-                  onBlur={() => setTimeout(() => setShowViewMenu(false), 150)}
-                  className="flex items-center gap-1.5 rounded-lg bg-white/90 dark:bg-slate-800/90 backdrop-blur-sm border border-slate-200 dark:border-slate-700 px-3 py-1.5 shadow-sm text-xs text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:border-slate-300 transition-colors"
-                  title="Change view"
+                  onClick={() => setShowMinimap((v) => !v)}
+                  className={`flex items-center gap-1.5 rounded-lg backdrop-blur-sm border px-2.5 py-1.5 shadow-sm text-xs transition-colors ${
+                    showMinimap
+                      ? 'bg-blue-50 dark:bg-blue-950/40 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-300'
+                      : 'bg-white/90 dark:bg-slate-800/90 border-slate-200 dark:border-slate-700 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:border-slate-300'
+                  }`}
+                  title={showMinimap ? 'Hide minimap' : 'Show minimap'}
                 >
                   <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    {viewMode === 'table' ? (
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 01-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0112 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M12 10.875v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125M13.125 12h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125M20.625 12c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5M12 14.625v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 14.625c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m0 0v.75" />
-                    ) : viewMode === 'map' ? (
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 6.75V15m6-6v8.25m.503 3.498l4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 00-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0z" />
-                    ) : (
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 14.25v2.25m3-4.5v4.5m3-6.75v6.75m3-9v9M6 20.25h12A2.25 2.25 0 0020.25 18V6A2.25 2.25 0 0018 3.75H6A2.25 2.25 0 003.75 6v12A2.25 2.25 0 006 20.25z" />
-                    )}
-                  </svg>
-                  <span className="hidden xl:inline">{{ graph: 'Graph', table: 'Table', map: 'Map' }[viewMode]}</span>
-                  <svg className="h-3 w-3 xl:-ml-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 6.75V15m6-6v8.25m.503 3.498l4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 00-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0z" />
                   </svg>
                 </button>
-                {showViewMenu && (
-                  <div className="absolute right-0 top-full mt-1 w-28 rounded-lg bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 shadow-lg py-1 z-50">
-                    {([
-                      { value: 'graph' as const, label: 'Graph' },
-                      { value: 'table' as const, label: 'Table' },
-                      { value: 'map' as const, label: 'Map' },
-                    ] as const).map((opt) => (
-                      <button
-                        key={opt.value}
-                        onMouseDown={() => { setViewMode(opt.value); setShowViewMenu(false); }}
-                        className={`flex items-center gap-2 w-full px-3 py-2 text-xs transition-colors ${
-                          viewMode === opt.value
-                            ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium'
-                            : 'text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700/50'
-                        }`}
-                      >
-                        {opt.label}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
+              )}
               {/* Layout picker */}
-              {viewMode !== 'table' && (
+              {viewMode === 'graph' && (
                 <div className="relative">
                   <button
                     onClick={() => setShowLayoutMenu((v) => !v)}
@@ -740,7 +729,7 @@ export function HomePage() {
                 </div>
               );
             })()}
-            {viewMode !== 'table' ? (
+            {viewMode === 'graph' ? (
               <Canvas
                 ref={canvasRef}
                 graphNodes={layoutNodes}
@@ -753,7 +742,7 @@ export function HomePage() {
                 fileName={state.fileName}
                 blastRadiusMode={blastRadiusMode}
                 costMap={costMap}
-                showMinimap={viewMode === 'map'}
+                showMinimap={showMinimap}
                 onBlastRadiusComputed={setBlastRadiusCount}
                 onNodeSelect={(id) =>
                   setState((prev) =>

--- a/apps/frontend/src/components/ProviderSelect.tsx
+++ b/apps/frontend/src/components/ProviderSelect.tsx
@@ -129,7 +129,7 @@ export function ProviderSelect({ onUpload, onTrySample, onTryCfnSample, onTryPla
 
             {/* Sample pill buttons */}
             <div className="flex flex-wrap items-center gap-2 mt-6">
-              <span className="text-sm text-slate-400 dark:text-slate-500">Try a sample:</span>
+              <span className="text-sm text-slate-500 dark:text-slate-500">Try a sample:</span>
               {samples.map((s) => (
                 <button
                   key={s.id}

--- a/apps/frontend/src/components/ResourceSummary.tsx
+++ b/apps/frontend/src/components/ResourceSummary.tsx
@@ -68,7 +68,7 @@ export function ResourceSummary({ resources, hiddenTypes, providerConfig, onTogg
 
   return (
     <div className="flex items-center gap-1 min-w-0 flex-nowrap">
-      <span className="text-xs font-medium text-slate-400 mr-1">{visibleCount} resources</span>
+      <span className="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full bg-slate-100 dark:bg-slate-700 text-xs font-semibold text-slate-600 dark:text-slate-300 mr-1">{visibleCount}</span>
       <span className="text-slate-200 dark:text-slate-600">|</span>
       {visibleEntries.map(([type, count]) => renderTypeButton(type, count))}
       {overflowEntries.length > 0 && (


### PR DESCRIPTION
## Summary
- Replace dropdown/segmented view control with a **simple toggle button**: shows "Table" in graph mode, "Graph" in table mode
- Add **icon-only minimap toggle** button (graph mode only, hidden by default)
- Replace "11 resources" text with a **compact number badge**
- Fix "Try a sample" label contrast in light mode (`text-slate-400` → `text-slate-500`)

## Test plan
- [x] Graph mode: toolbar shows "Table" button (not "Graph")
- [x] Table mode: toolbar shows "Graph" button
- [x] Minimap toggle works (icon-only, highlights blue when active)
- [x] Number badge shows resource count compactly
- [x] Light mode landing page is readable
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)